### PR TITLE
Remove empty check from ScannerService::fix

### DIFF
--- a/src/Service/ScannerService.php
+++ b/src/Service/ScannerService.php
@@ -42,10 +42,6 @@ class ScannerService implements ScannerServiceInterface
     {
         $concernedPaths = $this->scanner->getConcernedPaths();
 
-        if (empty($concernedPaths)) {
-            return;
-        }
-
         foreach ($concernedPaths as $concernedPath) {
             clearstatcache();
 


### PR DESCRIPTION
`foreach` deals with empty arrays very well 👌🏻

1 million loops in 25 ms instead of 20 ms with `empty`.
